### PR TITLE
build(sdk): update Node.js base image to version 20-alpine

### DIFF
--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Node.js image as the base
-FROM node:16-alpine
+FROM node:20-alpine
 
 RUN apk add --no-cache python3 python3-dev py3-pip build-base
 WORKDIR /app


### PR DESCRIPTION
Update the Node.js version in the Dockerfile from 16-alpine to 20-alpine to ensure compatibility with newer dependencies and leverage performance and security improvements in the latest Node.js version.