### PR TITLE
fix(sdk): gas fee calculation for transaction retries

### DIFF
--- a/sdk/src/miner.ts
+++ b/sdk/src/miner.ts
@@ -108,12 +108,13 @@ export class Miner {
             const feeData = await this.getFeeData();
 
             // Apply gas price multiplier for retries
-            const maxFeePerGas = feeData.maxFeePerGas
-                .mul(Math.floor(gasMultiplier * 100))
-                .div(100);
             const maxPriorityFeePerGas = feeData.maxPriorityFeePerGas
                 .mul(Math.floor(gasMultiplier * 100))
                 .div(100);
+
+            // Ensure maxFeePerGas is at least baseFeePerGas + maxPriorityFeePerGas
+            const baseFeePerGas = await this.forestContract.provider.getGasPrice();
+            const maxFeePerGas = baseFeePerGas.add(maxPriorityFeePerGas);
 
             // Log submission values
             this.log(`Submitting onboardBusQueue with:


### PR DESCRIPTION
Corrects the maxFeePerGas calculation in the Miner class to ensure it's always at least baseFeePerGas + maxPriorityFeePerGas. This addresses transaction failures where maxPriorityFeePerGas was higher than maxFeePerGas, which violates EIP-1559 requirements.

The fix retrieves the current baseFeePerGas from the provider and properly calculates maxFeePerGas to ensure it's always greater than or equal to the priority fee, preventing "max priority fee per gas higher than max fee per gas" errors during transaction retries with escalating gas prices.