### PR TITLE
feat(sdk): add network-specific claimReward scripts

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -17,6 +17,9 @@
     "generate:signature": "ts-node scripts/reward/generateSignature.ts",
     "claimRewardWithSignature": "ts-node scripts/reward/claimRewardWithSignature.ts",
     "claimReward": "ts-node scripts/reward/claimReward.ts",
+    "claimReward:canary": "env-cmd -f .env.canary ts-node scripts/reward/claimReward.ts",
+    "claimReward:polygon": "env-cmd -f .env.polygon ts-node scripts/reward/claimReward.ts",
+    "claimReward:base": "env-cmd -f .env.base ts-node scripts/reward/claimReward.ts",
     "build": "tsc",
     "gen:queues": "ts-node tests/generate-queues.ts"
   },

--- a/sdk/scripts/reward/claimReward.ts
+++ b/sdk/scripts/reward/claimReward.ts
@@ -16,20 +16,23 @@ const argv = yargs(process.argv)
     })
     .option('privateKey', {
         alias: 'pk',
-        description: 'Private key of the user triggering the function',
+        description: 'Private key of the user triggering the function (defaults to PRIVATE_KEY env)',
         type: 'string',
+        default: process.env.PRIVATE_KEY,
         demandOption: true,
     })
     .option('rpc', {
         alias: 'rpc',
-        description: 'RPC endpoint to connect to the blockchain',
+        description: 'RPC endpoint to connect to the blockchain (defaults to RPC_URL env)',
         type: 'string',
+        default: process.env.RPC_URL,
         demandOption: true,
     })
     .option('address', {
         alias: 'a',
-        description: 'Address of the ForestRoot contract',
+        description: 'Address of the ForestRoot contract (defaults to CONTRACT_ADDRESS env)',
         type: 'string',
+        default: process.env.CONTRACT_ADDRESS,
         demandOption: true,
     })
     .help()


### PR DESCRIPTION
## **User description**
## Summary
- Adds `claimReward:canary`, `claimReward:polygon`, and `claimReward:base` npm scripts that wrap `scripts/reward/claimReward.ts` with `env-cmd` so each loads the matching `.env.<network>` file.
- Updates the yargs config in `claimReward.ts` so `--privateKey`, `--rpc`, and `--address` default to the corresponding env vars (`PRIVATE_KEY`, `RPC_URL`, `CONTRACT_ADDRESS`) while remaining `demandOption: true` — the wrappers can omit the flags while bare invocations still error loudly when something is missing.
- Leaves the original `claimReward` script in place for backward compatibility.

## Test plan
- [ ] `npm run claimReward:polygon -- --receiver 0x...` claims using values from `.env.polygon`.
- [ ] `npm run claimReward:canary -- --receiver 0x...` claims using values from `.env.canary`.
- [ ] `npm run claimReward:base -- --receiver 0x...` claims using values from `.env.base` (once that file exists).
- [ ] `npm run claimReward -- --receiver 0x... --rpc ... --address ... --pk ...` still works as before.
- [ ] Running any wrapper without the corresponding env var present surfaces a yargs `Missing required argument` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add network-specific reward-claim commands that use the right environment settings automatically

### What Changed
- Added separate claim reward commands for canary, polygon, and base so each network can be run with its matching `.env` file
- The reward claim script now uses environment values for the private key, RPC URL, and contract address when they are available, so these commands can run without passing those values every time
- The original claim reward command still works for fully manual runs

### Impact
`✅ Shorter reward claims on each network`
`✅ Fewer missing-parameter errors when using network-specific commands`
`✅ Easier local runs with less command-line input`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=-7tIh68ps6tAbEZA9QPfiMLGlxWSTY-gMP6DNf3TCKE&org=pantherfoundation)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
