### PR TITLE
fix(sdk): use provider priority fee and chain-aware token symbol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ sdk/.env
 sdk/lib
 sdk/.env.canary
 sdk/.env.polygon
+sdk/.env.base
 
 web-client/node_modules
 web-client/build

--- a/sdk/scripts/reward/claimReward.ts
+++ b/sdk/scripts/reward/claimReward.ts
@@ -50,7 +50,8 @@ async function main() {
 
     try {
         const feeData = await provider.getFeeData();
-        const maxPriorityFeePerGas = BigNumber.from(30_000_000_000); // 30 gwei
+        const maxPriorityFeePerGas =
+            feeData.maxPriorityFeePerGas ?? BigNumber.from(30_000_000_000);
         const baseFeePerGas = feeData.lastBaseFeePerGas;
         if (!baseFeePerGas) {
           throw new Error("Could not retrieve base fee, cannot proceed with fee estimation.");

--- a/sdk/src/env.ts
+++ b/sdk/src/env.ts
@@ -5,6 +5,15 @@ import {providers, utils, Wallet} from 'ethers';
 
 import {EnvVariables} from './types';
 
+const nativeSymbolByChainId: Record<number, string> = {
+  1: 'ETH',
+  137: 'POL',
+  8453: 'ETH',
+  80001: 'POL',
+  80002: 'POL',
+  84532: 'ETH',
+};
+
 export const requiredVars: Array<keyof EnvVariables> = [
   'INTERVAL',
   'PRIVATE_KEY',
@@ -52,8 +61,15 @@ export async function logSettings(env: EnvVariables): Promise<void> {
 
       // Get the balance of the miner address
       const provider = new providers.JsonRpcProvider(env.RPC_URL);
-      const balance = await provider.getBalance(minerAddress);
-      logEnvVariable('MINER_BALANCE', utils.formatEther(balance) + ' POL');
+      const [balance, network] = await Promise.all([
+        provider.getBalance(minerAddress),
+        provider.getNetwork(),
+      ]);
+      const symbol = nativeSymbolByChainId[network.chainId] ?? 'ETH';
+      logEnvVariable(
+        'MINER_BALANCE',
+        `${utils.formatEther(balance)} ${symbol}`,
+      );
     } else {
       logEnvVariable(v, env[v]);
     }

--- a/sdk/src/miner.ts
+++ b/sdk/src/miner.ts
@@ -232,8 +232,9 @@ export class Miner {
     const provider = this.forestContract.provider;
     const feeData = await provider.getFeeData();
 
-    // Use reasonable defaults as the provider doesn't return values
-    const maxPriorityFeePerGas = BigNumber.from(30_000_000_000); // 30 gwei default
+    // Prefer provider-suggested priority fee; fall back to 30 gwei if absent.
+    const maxPriorityFeePerGas =
+      feeData.maxPriorityFeePerGas ?? BigNumber.from(30_000_000_000);
 
     // maxFeePerGas should be baseFeePerGas + maxPriorityFeePerGas
     const baseFeePerGas = feeData.lastBaseFeePerGas || BigNumber.from(0);


### PR DESCRIPTION
## **User description**
## Summary
- Stop hardcoding `maxPriorityFeePerGas = 30 gwei` in the miner and `claimReward` script. Now uses the provider's suggested priority fee (from `eth_maxPriorityFeePerGas`), falling back to 30 gwei only if the provider returns `null`. The previous behavior broke gas estimation on Base, where base fees are <0.01 gwei — combined with a small wallet balance, `eth_estimateGas` returned `gas required exceeds allowance` because the implied gas allowance (`balance / gasPrice`) capped at well below the call's needs.
- `MINER_BALANCE` log line was hardcoded to print `POL`. Now resolves the native token symbol from `chainId` (Mainnet / Base → ETH, Polygon → POL), so Base shows `ETH` correctly.
- Added `sdk/.env.base` to `.gitignore` so it doesn't get committed (the file holds a `PRIVATE_KEY`, like the existing `.env.polygon` / `.env.canary`).

## Test plan
- [ ] On Base mainnet (chainId 8453), run `yarn start:base` — confirm `MINER_BALANCE` logs `… ETH` and the miner can submit `onboardBusQueue` transactions without the `UNPREDICTABLE_GAS_LIMIT` / `gas required exceeds allowance` error.
- [ ] On Polygon (`yarn start:polygon`), confirm transactions still submit (the provider returns sensible priority fees, and the 30 gwei fallback still kicks in if it ever doesn't).
- [ ] Confirm `sdk/.env.base` is ignored by git (`git check-ignore sdk/.env.base`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Use network-suggested gas fees and show the correct native token symbol

### What Changed
- Transactions now use the fee suggested by the connected network instead of always assuming 30 gwei, which avoids gas estimation failures on low-fee chains like Base
- Reward-claiming follows the same fee behavior, keeping transaction submission consistent across networks
- Miner balance logs now show the correct native token symbol for the current chain, instead of always showing POL
- The Base environment file is kept out of version control

### Impact
`✅ Fewer gas estimation failures on Base`
`✅ More reliable transaction submission across chains`
`✅ Clearer miner balance logs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=uVndSBB2Dw3QXEcwZ6X28Tq-P59JGy7ZJ0K9mOA2GiY&org=pantherfoundation)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
