### PR TITLE
fix(sdk): floor priority fee on Polygon to avoid underpriced txs

### DIFF
--- a/sdk/scripts/reward/claimReward.ts
+++ b/sdk/scripts/reward/claimReward.ts
@@ -1,5 +1,8 @@
-import {ethers, BigNumber, utils} from 'ethers';
+import {ethers, utils} from 'ethers';
 import yargs from 'yargs';
+
+import {resolveMaxPriorityFeePerGas} from '../../src/gas';
+
 import {
     initializeContract,
     ClaimRewardArgs,
@@ -50,8 +53,10 @@ async function main() {
 
     try {
         const feeData = await provider.getFeeData();
-        const maxPriorityFeePerGas =
-            feeData.maxPriorityFeePerGas ?? BigNumber.from(30_000_000_000);
+        const maxPriorityFeePerGas = await resolveMaxPriorityFeePerGas(
+            provider,
+            feeData,
+        );
         const baseFeePerGas = feeData.lastBaseFeePerGas;
         if (!baseFeePerGas) {
           throw new Error("Could not retrieve base fee, cannot proceed with fee estimation.");

--- a/sdk/src/gas.ts
+++ b/sdk/src/gas.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2024 Panther Protocol Foundation
+
+import {BigNumber, providers, utils} from 'ethers';
+
+const FALLBACK_PRIORITY_FEE = utils.parseUnits('30', 'gwei');
+
+// Polygon's bor node rejects transactions with priority fee below ~25 gwei
+// as underpriced, even when eth_maxPriorityFeePerGas suggests a lower value.
+const MIN_PRIORITY_FEE_BY_CHAIN: Record<number, BigNumber> = {
+  137: utils.parseUnits('30', 'gwei'),
+  80001: utils.parseUnits('30', 'gwei'),
+  80002: utils.parseUnits('30', 'gwei'),
+};
+
+export async function resolveMaxPriorityFeePerGas(
+  provider: providers.Provider,
+  feeData: providers.FeeData,
+): Promise<BigNumber> {
+  const {chainId} = await provider.getNetwork();
+  const floor = MIN_PRIORITY_FEE_BY_CHAIN[chainId] ?? BigNumber.from(0);
+  const fromProvider = feeData.maxPriorityFeePerGas;
+
+  if (!fromProvider) {
+    return floor.gt(0) ? floor : FALLBACK_PRIORITY_FEE;
+  }
+  return fromProvider.gt(floor) ? fromProvider : floor;
+}

--- a/sdk/src/miner.ts
+++ b/sdk/src/miner.ts
@@ -5,6 +5,7 @@ import {type ContractReceipt, Wallet, utils, BigNumber} from 'ethers';
 
 import {BusQueues, ForestTree} from './contract/forest-types';
 import {initializeBusContract} from './contracts';
+import {resolveMaxPriorityFeePerGas} from './gas';
 import {LogFn, log as defaultLog} from './logging';
 import {BusQueueRecStructOutput} from './types';
 
@@ -232,9 +233,10 @@ export class Miner {
     const provider = this.forestContract.provider;
     const feeData = await provider.getFeeData();
 
-    // Prefer provider-suggested priority fee; fall back to 30 gwei if absent.
-    const maxPriorityFeePerGas =
-      feeData.maxPriorityFeePerGas ?? BigNumber.from(30_000_000_000);
+    const maxPriorityFeePerGas = await resolveMaxPriorityFeePerGas(
+      provider,
+      feeData,
+    );
 
     // maxFeePerGas should be baseFeePerGas + maxPriorityFeePerGas
     const baseFeePerGas = feeData.lastBaseFeePerGas || BigNumber.from(0);


### PR DESCRIPTION
## **User description**
## Summary
Regression fix for #19. Polygon's bor node enforces a minimum priority fee of ~25 gwei, but `eth_maxPriorityFeePerGas` (called by ethers' `getFeeData`) often returns ~1–2 gwei via Infura. PR #19 switched the miner to trust that provider value, which caused `eth_sendRawTransaction` to fail with `-32000 transaction underpriced` on Polygon (even after the retry multiplier ramped up).

This PR adds a chain-specific minimum floor: take `max(provider-suggested, floor)`, where `floor` is 30 gwei for Polygon mainnet/Mumbai/Amoy and 0 elsewhere. Base and Mainnet keep the provider-suggested value, so the original Base fix is preserved.

The shared resolution logic is now in `sdk/src/gas.ts` and used from both `Miner.getFeeData` and `claimReward`.

## Test plan
- [ ] On Polygon mainnet (`yarn start:polygon`), confirm `Current gas prices` log shows `maxPriorityFeePerGas >= 30 gwei` and tx submission no longer hits `-32000 underpriced`.
- [ ] On Base mainnet (`yarn start:base`), confirm priority fee is still the (low) provider-suggested value and tx submission still works.
- [ ] On Polygon, run `yarn claimReward:polygon -- -r 0x...` against a low-balance wallet — should not regress.
- [ ] `cd sdk && yarn build` is clean (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Avoid underpriced Polygon transactions by enforcing a minimum priority fee**

### What Changed
- Polygon transactions now use a minimum 30 gwei priority fee when the provider suggests a lower value or none at all, preventing `underpriced` failures.
- The reward-claim flow and the miner now use the same fee selection rule, so both paths behave consistently.
- Other networks keep using the fee suggested by the provider.

### Impact
`✅ Fewer Polygon transaction failures`
`✅ Clearer fee handling on reward claims`
`✅ Consistent transaction pricing across SDK flows`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=Se_lrwYg3jhcprNd-qCbXwLzyBWB9BhUUaml2-QwUJ0&org=pantherfoundation)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
